### PR TITLE
Update README.md mentioning zigpy dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ZigBee Controller with HTTP API (ZigCoHTTP)
 
-This python application creates a ZigBee network using [bellows](https://github.com/zigpy/bellows). ZigBee devices joining this network can be controlled via a HTTP API. It was developed for a Rasperry Pi using a [Matrix Creator Board](https://www.matrix.one/products/creator) but should also work with other hardware.
+This python application creates a ZigBee network using [zigpy](https://github.com/zigpy/zigpy) and [bellows](https://github.com/zigpy/bellows). ZigBee devices joining this network can be controlled via a HTTP API. It was developed for a Rasperry Pi using a [Matrix Creator Board](https://www.matrix.one/products/creator) but should also work with other computers with Silicon Labs Zigbee hardware.
 
 ## Requirements
 
-* compatible hardware (see https://github.com/zigpy/bellows)
+* Compatible Zigbee hardware (see https://github.com/zigpy/bellows)
 * Python 3 and pip
 
 ## Installation


### PR DESCRIPTION
@daniel17903 Update README.md mentioning zigpy dependency as it is required while bellows should really be replaced by other radio libraries for zigpy as per https://github.com/zigpy/zigpy/blob/dev/README.md